### PR TITLE
Corrected syntax error and added new vars

### DIFF
--- a/language/spanish/lang.fbc.php
+++ b/language/spanish/lang.fbc.php
@@ -204,7 +204,7 @@ al panel de control del módulo en el Panel de Control de ExpressionEngine",
 "Actualizar el módulo FBC",
 
 'fbc_update_message' =>
-"Parece que has subido una nueva versión del FBC. Por favor ejecute el script de actualización, haga clic en el botón 'Actualizar' de abajo".,
+"Parece que has subido una nueva versión del FBC. Por favor ejecute el script de actualización, haga clic en el botón 'Actualizar' de abajo.",
 
 //----------------------------------------
 //  API errors


### PR DESCRIPTION
New vars are in English for now till translation is completed, but prevents missing var errors.
